### PR TITLE
Reduce sdk web distribution size

### DIFF
--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -253,7 +253,7 @@ class StarfishService
             callback(null, response);
           })
           .catch(function (err) {
-            callback(err, null);
+            callback(err);
           });
       }
     });
@@ -279,7 +279,7 @@ class StarfishService
             callback(null, response);
           })
           .catch(function (err) {
-            callback(err, null);
+            callback(err);
           });
       }
     });
@@ -304,7 +304,7 @@ class StarfishService
             callback(null, response);
           })
           .catch(function (err) {
-            callback(err, null);
+            callback(err);
           });
       }
     });

--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -29,11 +29,21 @@ Spring Networks, Inc.
 
 'use strict';
 
-const rp = require('request-promise-native');
-const jwt = require('jsonwebtoken');
+import 'isomorphic-fetch';
+
+const rp = ({uri, method, headers, body}) => {
+  const options = {method, headers};
+
+  if (method === 'POST') {
+    options.body = JSON.stringify(body)
+  }
+  return fetch(uri, options).then(response => response.json())
+};
+
 
 const tokenHasExpired = token => {
-  const exp = new Date(jwt.decode(token).exp * 1000);
+  const body = JSON.parse(Buffer.from(token.split('.')[1], 'base64'));
+  const exp = new Date(body.exp * 1000);
   const now = new Date();
   return exp < now;
 };
@@ -144,7 +154,7 @@ class StarfishService
         console.log("Get Devices Options: " + JSON.stringify(options, null, 2));
         rp(options)
           .then((response) => {
-              console.log('Get Devices Response:' + JSON.stringify(response.devices, null, 2));
+              console.log('Get Devices Response:' + JSON.stringify(response, null, 2));
               if(response.devices && response.devices.length > 0) {
                 return callback(null, response.devices);
               }

--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -103,7 +103,7 @@ class StarfishService
     try {
       needsRefresh = this._shouldRefreshToken()
     } catch (error) {
-      return callback(`Token Error: ${error.message}`)
+      return callback(new Error(`Token Error: ${error.message}`))
     }
     if (needsRefresh) {
       this.getToken(this.clientId, this.secret, (error, token) => {

--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -92,13 +92,20 @@ class StarfishService
 
   _shouldRefreshToken() {
     if (this.secret) {
+      let expired = true;
       return !this.token || tokenHasExpired(this.token);
     }
     return false;
   }
 
   withToken(callback) {
-    if (this._shouldRefreshToken()) {
+    let needsRefresh;
+    try {
+      needsRefresh = this._shouldRefreshToken()
+    } catch (error) {
+      return callback(`Token Error: ${error.message}`)
+    }
+    if (needsRefresh) {
       this.getToken(this.clientId, this.secret, (error, token) => {
         if(error) {
           callback(error);

--- a/package.json
+++ b/package.json
@@ -32,11 +32,10 @@
     "mocha": "3.1.2",
     "mockery": "2.0.0",
     "sinon": "1.17.6",
-    "webpack": "2.2.1"
+    "webpack": "2.2.1",
+    "jsonwebtoken": "7.1.9"
   },
   "dependencies": {
-    "jsonwebtoken": "7.1.9",
-    "request": "2.78.0",
-    "request-promise-native": "1.0.3"
+    "isomorphic-fetch": "2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "babel-preset-env": "1.2.2",
     "babel-preset-es2015": "6.24.0",
     "chai": "3.5.0",
+    "jsonwebtoken": "7.1.9",
     "mocha": "3.1.2",
     "mockery": "2.0.0",
-    "webpack": "2.2.1",
-    "jsonwebtoken": "7.1.9"
+    "sinon-test": "1.0.1",
+    "webpack": "2.2.1"
   },
   "dependencies": {
     "isomorphic-fetch": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "chai": "3.5.0",
     "mocha": "3.1.2",
     "mockery": "2.0.0",
-    "sinon": "1.17.6",
     "webpack": "2.2.1",
     "jsonwebtoken": "7.1.9"
   },
   "dependencies": {
-    "isomorphic-fetch": "2.2.1"
+    "isomorphic-fetch": "2.2.1",
+    "sinon": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "starfish-sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Javascript wrapper for Starfish APIs",
   "main": "dist/starfish.js",
   "scripts": {
-    "test": "npm run build && mocha --compilers js:babel-core/register ./test/*",
+    "test": "mocha --compilers js:babel-core/register ./test/*",
     "prepublish": "npm run build",
     "build": "babel lib --out-dir dist",
     "webpack": "webpack -p"
@@ -31,12 +31,11 @@
     "chai": "3.5.0",
     "jsonwebtoken": "7.1.9",
     "mocha": "3.1.2",
-    "mockery": "2.0.0",
+    "sinon": "2.1.0",
     "sinon-test": "1.0.1",
     "webpack": "2.2.1"
   },
   "dependencies": {
-    "isomorphic-fetch": "2.2.1",
-    "sinon": "2.1.0"
+    "isomorphic-fetch": "2.2.1"
   }
 }

--- a/test/test_starfish.js
+++ b/test/test_starfish.js
@@ -494,7 +494,7 @@ describe('StarfishService', () =>  {
           service.token = "not a valid token";
 
           call((error, result) => {
-            expect(error).to.exist;
+            expect(error).to.be.an.instanceOf(Error);
             expect(result).to.not.exist;
             done();
           });

--- a/test/test_starfish.js
+++ b/test/test_starfish.js
@@ -1,6 +1,6 @@
 /*
 Copyright (c) Silver Spring Networks, Inc.
-s
+
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/test/test_starfish.js
+++ b/test/test_starfish.js
@@ -1,6 +1,6 @@
 /*
 Copyright (c) Silver Spring Networks, Inc.
-
+s
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -487,6 +487,19 @@ describe('StarfishService', () =>  {
             done();
           });
         });
+        it("should call callback with error if token is not valid", done => {
+          fetch.onFirstCall().resolves(new Response(JSON.stringify({accessToken: freshToken})))
+          fetch.onSecondCall().resolves(new Response(JSON.stringify(scenario.response)))
+
+          service.token = "not a valid token";
+
+          call((error, result) => {
+            expect(error).to.exist;
+            expect(result).to.not.exist;
+            done();
+          });
+
+        })
         it("should not call getToken if the token is fresh", sinon.test(function(done)  {
           fetch.onFirstCall().resolves(new Response(JSON.stringify(scenario.response)))
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,3 +1,4 @@
+
 var path = require('path');
 var webpack = require('webpack');
 


### PR DESCRIPTION
Reduces the size of the web distributable from over 1MB to just 35KB by removing some dependencies and switching to isomorphic fetch instead of request-promise.