### PR TITLE
GET Devices API has a new filter by `deviceType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ The following examples assume that you have an instance of starfish named `starf
   })
 ```
 
+### Query Devices by `deviceType`
+
+```js
+  starfish.queryDevices({deviceType:'type'}, (err, data) => {
+    if(err) {
+      console.log("Error:", err)
+    } else {
+      console.log("Return devices: ", data)
+    }
+  })
+```
+
 ### Get Device Observations
 
 ```js

--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -146,7 +146,10 @@ class StarfishService
   }
 
   getDevices(callback) {
-    //retreive from starfish
+    return this.queryDevices({}, callback);
+  }
+
+  queryDevices(querystring, callback) {
     this.withToken((error, token) => {
       if (error) {
         callback(error);
@@ -154,6 +157,7 @@ class StarfishService
         var options = {
           method: 'GET',
           uri: this.apiBaseUrl + '/api/solutions/' + this.solution + "/devices",
+          qs: querystring,
           headers: {
               'Authorization': token
           },

--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -31,10 +31,18 @@ Spring Networks, Inc.
 
 import 'isomorphic-fetch';
 
-const rp = ({uri, method, headers, body}) => {
+const queryParams = (params) => {
+   return Object.keys(params)
+     .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
+     .join('&');
+}
+
+const rp = ({uri, qs, method, headers, body}) => {
   headers = Object.assign({}, headers, {"Content-Type": "application/json"})
   const options = {method, headers};
-
+  if (qs) {
+    uri += (uri.indexOf('?') === -1 ? '?' : '&') + queryParams(qs);
+  }
   if (method === 'POST') {
     options.body = JSON.stringify(body)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starfish-sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Javascript wrapper for Starfish APIs",
   "main": "dist/starfish.js",
   "scripts": {

--- a/test/test_starfish.js
+++ b/test/test_starfish.js
@@ -447,6 +447,7 @@ describe('StarfishService', () =>  {
     [
       {method: "getObservations", args: [], response: {}},
       {method: "getDevices", args: [], response: {devices: []}},
+      {method: "queryDevices", args: [{deviceType: 'ap'}], response: {}},
       {method: "queryObservations", args: [{from: 'x', to: 'y'}], response: {}},
       {method: "postDeviceObservation", args: ["did", {}], response: {}},
       {method: "getDeviceObservations", args: ["did"], response: {}},

--- a/test/test_starfish.js
+++ b/test/test_starfish.js
@@ -612,4 +612,52 @@ describe('StarfishService', () =>  {
       });
     });
   });
+  describe('querystring', () => {
+    describe('queryDevices', () => {
+      it("should use the querystring if passed", (done) => {
+        const qs = {param1:'value1'};
+        const expectedQueryString = "?param1=value1";
+
+        const service = new StarfishService(host, solution, token);
+        fetch.onFirstCall().returns(Promise.resolve(new Response('{}')));
+
+        service.queryDevices(qs, (error, response) => {
+          expect(fetch.firstCall.args[0]).has.match(new RegExp("^.*" + expectedQueryString + "$"));
+          done();
+        });
+      });
+      it("should not add any querystring if not passed", (done) => {
+        const service = new StarfishService(host, solution, token);
+        fetch.onFirstCall().returns(Promise.resolve(new Response('{}')));
+
+        service.queryDevices(null, (error, response) => {
+          expect(fetch.firstCall.args[0]).has.match(new RegExp("^.*devices$"));
+          done();
+        });
+      });
+    });
+    describe('queryObservations', () => {
+      it("should use the querystring if passed", (done) => {
+        const qs = {param1:'value1', param2:'value2'};
+        const expectedQueryString = "?param1=value1&param2=value2";
+
+        const service = new StarfishService(host, solution, token);
+        fetch.onFirstCall().returns(Promise.resolve(new Response('{}')));
+
+        service.queryObservations(qs, (error, response) => {
+          expect(fetch.firstCall.args[0]).has.match(new RegExp("^.*" + expectedQueryString + "$"));
+          done();
+        });
+      });
+      it("should not add any querystring if not passed", (done) => {
+        const service = new StarfishService(host, solution, token);
+        fetch.onFirstCall().returns(Promise.resolve(new Response('{}')));
+
+        service.queryObservations(null, (error, response) => {
+          expect(fetch.firstCall.args[0]).has.match(new RegExp("^.*observations$"));
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
   StarfishService now exposes a new API `queryDevices(querystring, callback)`
   to allow users to pass in deviceType filters.