### PR TITLE
Fix to use Buffer constructor

### DIFF
--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -51,7 +51,7 @@ const rp = ({uri, qs, method, headers, body}) => {
 
 
 const tokenHasExpired = token => {
-  const body = JSON.parse(Buffer.from(token.split('.')[1], 'base64'));
+  const body = JSON.parse(new Buffer(token.split('.')[1], 'base64'));
   const exp = new Date(body.exp * 1000);
   const now = new Date();
   return exp < now;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starfish-sdk",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Javascript wrapper for Starfish APIs",
   "main": "dist/starfish.js",
   "scripts": {


### PR DESCRIPTION
Using new Buffer(string, 'base64') to support old versions of node.

Constructor seems to be deprecated in v5.10+ and Buffer.from is preferred.
So,

- Avoid validating expiry as APIs do it any way.
- Find a better solution to support decoding token across node versions.

Until then just using the deprecated constructor.

this closes #12