### PR TITLE
Add a time range filter for device observations.

### DIFF
--- a/lib/starfish.js
+++ b/lib/starfish.js
@@ -219,7 +219,7 @@ class StarfishService
     });
   }
 
-  getDeviceObservations(deviceId, callback) {
+  queryDeviceObservations(deviceId, querystring, callback) {
     this.withToken((error, token) => {
       if (error) {
         callback(error);
@@ -227,6 +227,7 @@ class StarfishService
         var options = {
           method: 'GET',
           uri: this.apiBaseUrl + '/api/solutions/' + this.solution + '/devices/' + deviceId + "/observations",
+          qs: querystring,
           headers: {
               'Authorization': token
           },
@@ -249,8 +250,12 @@ class StarfishService
     });
   }
 
+  getDeviceObservations(deviceId, callback) {
+    return this.queryDeviceObservations(deviceId, null, callback);
+  }
+
   getObservations(callback) {
-    return this.queryObservations({}, callback);
+    return this.queryObservations(null, callback);
   }
 
   postDeviceObservation(deviceId, observation, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starfish-sdk",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Javascript wrapper for Starfish APIs",
   "main": "dist/starfish.js",
   "scripts": {

--- a/test/test_starfish.js
+++ b/test/test_starfish.js
@@ -449,6 +449,7 @@ describe('StarfishService', () =>  {
       {method: "getDevices", args: [], response: {devices: []}},
       {method: "queryDevices", args: [{deviceType: 'ap'}], response: {}},
       {method: "queryObservations", args: [{from: 'x', to: 'y'}], response: {}},
+      {method: "queryDeviceObservations", args: ["did", {from: 'x', to: 'y'}], response: {}},
       {method: "postDeviceObservation", args: ["did", {}], response: {}},
       {method: "getDeviceObservations", args: ["did"], response: {}},
       {method: "postDevice", args: [{}], response: {}},
@@ -654,6 +655,29 @@ describe('StarfishService', () =>  {
         fetch.onFirstCall().returns(Promise.resolve(new Response('{}')));
 
         service.queryObservations(null, (error, response) => {
+          expect(fetch.firstCall.args[0]).has.match(new RegExp("^.*observations$"));
+          done();
+        });
+      });
+    });
+    describe('queryDeviceObservations', () => {
+      it("should use the querystring if passed", (done) => {
+        const qs = {param1:'value1', param2:'value2'};
+        const expectedQueryString = "?param1=value1&param2=value2";
+
+        const service = new StarfishService(host, solution, token);
+        fetch.onFirstCall().returns(Promise.resolve(new Response('{}')));
+
+        service.queryDeviceObservations("did", qs, (error, response) => {
+          expect(fetch.firstCall.args[0]).has.match(new RegExp("^.*" + expectedQueryString + "$"));
+          done();
+        });
+      });
+      it("should not add any querystring if not passed", (done) => {
+        const service = new StarfishService(host, solution, token);
+        fetch.onFirstCall().returns(Promise.resolve(new Response('{}')));
+
+        service.queryDeviceObservations("did", null, (error, response) => {
           expect(fetch.firstCall.args[0]).has.match(new RegExp("^.*observations$"));
           done();
         });


### PR DESCRIPTION
   A new queryDeviceObservations(deviceId, querystring, callback)
   is added to the interface to provide querying specific device
   observations by a given time range using 'from' & 'to' query strings.